### PR TITLE
Add Get Flights parameters to request

### DIFF
--- a/FlightRadar24/api.py
+++ b/FlightRadar24/api.py
@@ -79,7 +79,7 @@ class FlightRadar24API(object):
         request = APIRequest(Core.flight_data_url.format(flight_id), headers = Core.json_headers)
         return request.get_content()
 
-    def get_flights(self, airline = None, bounds = None):
+    def get_flights(self, airline = None, bounds = None, vehicles = False, gnd = False, air = True):
 
         """
         Parameter airline: must be the airline ICAO. Ex: "DAL"
@@ -91,6 +91,10 @@ class FlightRadar24API(object):
         # Insert the parameters "airline" and "bounds" in the dictionary for the request.
         if airline: request_params["airline"] = airline
         if bounds: request_params["bounds"] = bounds.replace(",", "%2C")
+        
+        request_params["vehicles"] = vehicles
+        request_params["gnd"] = gnd
+        request_params["air"] = air
 
         # Get all flights from Data Live Flightradar24.
         request = APIRequest(Core.real_time_flight_tracker_data_url, request_params, Core.json_headers)

--- a/FlightRadar24/api.py
+++ b/FlightRadar24/api.py
@@ -86,12 +86,16 @@ class FlightRadar24API(object):
         Parameter bounds: must be coordinates (y1, y2 ,x1, x2). Ex: "75.78,-75.78,-427.56,427.56"
         """
 
+        vehicles = 1 if vehicles else 0
+        gnd = 1 if gnd else 0
+        air = 1 if air else 0
+
         request_params = self.__real_time_flight_tracker_config.copy()
 
         # Insert the parameters "airline" and "bounds" in the dictionary for the request.
         if airline: request_params["airline"] = airline
         if bounds: request_params["bounds"] = bounds.replace(",", "%2C")
-        
+
         request_params["vehicles"] = vehicles
         request_params["gnd"] = gnd
         request_params["air"] = air


### PR DESCRIPTION
This PR adds 3 parameters in `get_flights` method from _api.py_.

1. Vehicles : Do we want vehicles too ?
2. Ground : Do we want flights on the ground ? (Airports before departure and after arrival)
3. Air : Do we want flights in the air ?

No tests have been written, but it works.
If you are interested, I can implement some basic tests.