### PR TITLE
Implement method to get ICAO model from Flight class

### DIFF
--- a/FlightRadar24/__init__.py
+++ b/FlightRadar24/__init__.py
@@ -13,4 +13,4 @@ https://www.flightradar24.com/terms-and-conditions
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "1.2.7"
+__version__ = "1.2.8"

--- a/FlightRadar24/flight.py
+++ b/FlightRadar24/flight.py
@@ -82,6 +82,9 @@ class Flight(object):
     def get_vertical_speed(self) -> str:
         return "{} fpm".format(self.vertical_speed)
 
+    def get_icao_model(self) -> str:
+        return str(self.icao_24bit)
+
     def set_flight_details(self, flight_details: Dict) -> None:
         
         # Get aircraft data.


### PR DESCRIPTION
Allow the user to directly obtain the ICAO model code from Flight objects rather than indirectly getting flight details or string manipulation