### PR TITLE
query search + retrieving most tracked methods

### DIFF
--- a/FlightRadar24/api.py
+++ b/FlightRadar24/api.py
@@ -242,6 +242,32 @@ class FlightRadar24API(object):
 
         return zones
 
+    def search(self, query: str) -> Dict:
+        """
+        Return the search result
+        """
+        response = APIRequest(Core.search_data_url.format(query), headers = Core.json_headers)
+        results = response.get_content().get("results", [])
+        stats = response.get_content().get("stats", {})
+
+        i = 0
+        counted_total = 0
+        data = {}
+        for name, count in stats.get("count", {}).items():
+            data[name] = []
+            while i < counted_total + count and i < len(results):
+                data[name].append(results[i])
+                i += 1
+            counted_total += count
+        return data
+
+    def get_most_tracked(self) -> Dict:
+        """
+        Return the most tracked data
+        """
+        response = APIRequest(Core.most_tracked_url, headers = Core.json_headers)
+        return response.get_content()
+
     def is_logged_in(self) -> bool:
         """
         Check if the user is logged into the FlightRadar24 account.

--- a/FlightRadar24/core.py
+++ b/FlightRadar24/core.py
@@ -16,6 +16,12 @@ class Core(ABC):
     user_login_url = flightradar_base_url + "/user/login"
     user_logout_url = flightradar_base_url + "/user/logout"
 
+    # Most tracked data URL
+    most_tracked_url = flightradar_base_url + "/flights/most-tracked"
+
+    # Search data URL
+    search_data_url = flightradar_base_url + "/v1/search/web/find?query={}&limit=50"
+
     # Flights data URLs.
     real_time_flight_tracker_data_url = data_cloud_base_url + "/zones/fcgi/feed.js"
     flight_data_url = data_live_base_url + "/clickhandler/?flight={}"


### PR DESCRIPTION
Data retrieved from query is being "sorted" to the dict with search result categories (e.g. Live, Scheduled, Airlines and etc.)