### PR TITLE
Add Historical Data Download Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .idea/
 venv/
 node_modules/
+.env

--- a/python/FlightRadar24/core.py
+++ b/python/FlightRadar24/core.py
@@ -23,6 +23,9 @@ class Core(ABC):
     real_time_flight_tracker_data_url = data_cloud_base_url + "/zones/fcgi/feed.js"
     flight_data_url = data_live_base_url + "/clickhandler/?flight={}"
 
+    # Historical data URL.
+    historical_data_url = flightradar_base_url + "/download/?flight={}&file={}&trailLimit=0&history={}"
+
     # Airports data URLs.
     api_airport_data_url = api_flightradar_base_url + "/airport.json"
     airport_data_url = flightradar_base_url + "/airports/traffic-stats/?airport={}"

--- a/python/FlightRadar24/errors.py
+++ b/python/FlightRadar24/errors.py
@@ -15,3 +15,9 @@ class CloudflareError(Exception):
 
 class LoginError(Exception):
     pass
+
+class FileTypeError(Exception):
+    pass
+
+class FlightIDError(Exception):
+    pass

--- a/python/README.md
+++ b/python/README.md
@@ -103,6 +103,16 @@ distance = flight.get_distance_from(airport)
 print(f"The flight is {distance} km away from the airport.")
 ```
 
+## Downloading Flight Data
+*Note*: This requires a premium subscription and for you to be logged in.
+
+```py
+history_data = fr_api.get_history_data(flight_id='33ca11c4', file_type='csv', time=1706529600)
+
+ with open('history_data.csv', 'w') as f:
+    f.write(history_data)
+```
+
 ## Setting and getting Real-time Flight Tracker parameters:
 Set it by using the `set_flight_tracker_config(...)` method. It receives a `FlightTrackerConfig` dataclass instance, but
 you can also use keyword arguments directly to the method.

--- a/python/README.md
+++ b/python/README.md
@@ -113,9 +113,9 @@ history_data = fr_api.get_history_data(flight_id='33ca11c4', file_type='csv', ti
     f.write(history_data)
 ```
 
-`flight_id` - The ID of the flight
-`file_type` - Either CSV or KML
-`time` - The STD/scheduled time of deperature in UTC of the flight
+`flight_id` - The ID of the flight. Can be gotten from any other function that returns flight details.
+`file_type` - Either CSV or KML.
+`time` - The STD/scheduled time of deperature in UTC of the flight. Putting an invalid time will return a blank document.
 
 ## Setting and getting Real-time Flight Tracker parameters:
 Set it by using the `set_flight_tracker_config(...)` method. It receives a `FlightTrackerConfig` dataclass instance, but

--- a/python/README.md
+++ b/python/README.md
@@ -115,7 +115,7 @@ history_data = fr_api.get_history_data(flight_id='33ca11c4', file_type='csv', ti
 
 `flight_id` - The ID of the flight. Can be gotten from any other function that returns flight details.
 `file_type` - Either CSV or KML.
-`time` - The STD/scheduled time of deperature in UTC of the flight. Putting an invalid time will return a blank document.
+`time` - The STD/scheduled time of deperature in UTC of the flight as a Unix timestamp. Putting an invalid time will return a blank document.
 
 ## Setting and getting Real-time Flight Tracker parameters:
 Set it by using the `set_flight_tracker_config(...)` method. It receives a `FlightTrackerConfig` dataclass instance, but

--- a/python/README.md
+++ b/python/README.md
@@ -113,6 +113,10 @@ history_data = fr_api.get_history_data(flight_id='33ca11c4', file_type='csv', ti
     f.write(history_data)
 ```
 
+`flight_id` - The ID of the flight
+`file_type` - Either CSV or KML
+`time` - The STD/scheduled time of deperature in UTC of the flight
+
 ## Setting and getting Real-time Flight Tracker parameters:
 Set it by using the `set_flight_tracker_config(...)` method. It receives a `FlightTrackerConfig` dataclass instance, but
 you can also use keyword arguments directly to the method.


### PR DESCRIPTION
This PR adds a new function that allows users to download a CSV or KML file of a playback of a particular flight

This does require a premium FlightRadar24 subscription and for you to be logged in. Additionally, depending on your subscription status, there is a limit to the amount of files you can download per day.

You need to provide a `flight_id`, `file_type` (CSV or KML) and `time` (a Unix timestamp).

For example:
```py
history_data = fr_api.get_history_data(flight_id='33ca11c4', file_type='csv', time=1706529600)

 with open('history_data.csv', 'w') as f:
    f.write(history_data)
```

Would return CSV for flight AA1.

The time in this example is Monday Jan 29 2024 7:00:00 local time which is Monday Jan 29 2024 12:00:00 GMT time. As a Unix timestamp this is: 1706529600.

Unfortunately, I don't know JS so I could only add this function in Python.