### PR TITLE
Update Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FlightRadarAPI
-Unofficial SDK for [FlightRadar24](https://www.flightradar24.com/) for Python 3 and NodeJS.
+Unofficial SDK for [FlightRadar24](https://www.flightradar24.com/) for Python 3 and Node.js.
 
 If you want to use the data collected using this SDK commercially, you need to subscribe to the [Business plan](https://www.flightradar24.com/premium/).</br>
 See more information at: https://www.flightradar24.com/terms-and-conditions
@@ -11,15 +11,9 @@ See more information at: https://www.flightradar24.com/terms-and-conditions
 [![Npm](https://img.shields.io/npm/v/flightradarapi?logo=npm&color=red)](https://www.npmjs.com/package/flightradarapi)
 [![Downloads](https://static.pepy.tech/personalized-badge/flightradarapi?period=total&units=international_system&left_color=grey&right_color=orange&left_text=downloads)](https://pypi.org/project/FlightRadarAPI/)
 [![Frequency](https://img.shields.io/pypi/dm/flightradarapi?style=flat&label=frequency)](https://pypi.org/project/FlightRadarAPI/)
+
 ## Installing FlightRadarAPI
-**For Python with pip:**
-```
-pip install FlightRadarAPI
-```
-**For NodeJS with npm:**
-```
-npm install flightradarapi
-```
+Installation information is available on the [documentation](https://JeanExtreme002.github.io/FlightRadarAPI/).
 
 ## Documentation
-Explore the documentation of FlightRadarAPI package, for Python or NodeJS, through [this site](https://JeanExtreme002.github.io/FlightRadarAPI/)
+Explore the documentation of FlightRadarAPI package, for Python or NodeJS, through [this site](https://JeanExtreme002.github.io/FlightRadarAPI/).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ See more information at: https://www.flightradar24.com/terms-and-conditions
 [![Frequency](https://img.shields.io/pypi/dm/flightradarapi?style=flat&label=frequency)](https://pypi.org/project/FlightRadarAPI/)
 
 ## Installing FlightRadarAPI
-Installation information is available on the [documentation](https://JeanExtreme002.github.io/FlightRadarAPI/).
+**For Python with pip:**
+```
+pip install FlightRadarAPI
+```
+
+**For Node.js with npm:**
+```
+npm install flightradarapi
+```
 
 ## Documentation
 Explore the documentation of FlightRadarAPI package, for Python or NodeJS, through [this site](https://JeanExtreme002.github.io/FlightRadarAPI/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # FlightRadarAPI Documentation
 
-Unofficial SDK for [FlightRadar24](https://www.flightradar24.com/) for Python 3 and NodeJS.
+Unofficial SDK for [FlightRadar24](https://www.flightradar24.com/) for Python 3 and Node.js.
 
 If you want to use the data collected using this SDK commercially, you need to subscribe to the [Business plan](https://www.flightradar24.com/premium/).</br>
 See more information at: [https://www.flightradar24.com/terms-and-conditions](https://www.flightradar24.com/terms-and-conditions)
@@ -25,11 +25,11 @@ See more information at: [https://www.flightradar24.com/terms-and-conditions](ht
     The code is open source and available for inspection on GitHub.
 
 
--   :material-sticker-check-outline:{ .lg .middle } __Trustworthy Service__
+-   :material-sticker-check-outline:{ .lg .middle } __Python and Node.js__
 
     ---
 
-    All data is parsed from the FlightRadar24, which is a reliable source for real-time flight data.
+    Packages are avaiable for use on both Python and Node.js
 
 </div>
 
@@ -41,16 +41,18 @@ See more information at: [https://www.flightradar24.com/terms-and-conditions](ht
 
 ## Installation
 
-### Python
-To install FlightRadarAPI for Python using pip, run the following command in your terminal:
+=== "Python"
 
-```bash
-pip install FlightRadarAPI
-```
+    To install FlightRadarAPI for Python using [pip](https://pypi.org/project/FlightRadarAPI/), run the following command in your terminal:
 
-### NodeJS
-To install FlightRadarAPI for NodeJS using npm, run the following command in your terminal:
+    ```bash
+    pip install FlightRadarAPI
+    ```
 
-```bash
-npm install flightradarapi
-```
+=== "Node.js"
+
+    To install FlightRadarAPI for Node.js using [npm](https://www.npmjs.com/package/flightradarapi), run the following command in your terminal:
+
+    ```bash
+    npm install flightradarapi
+    ```

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -39,4 +39,4 @@ description: Nice projects that use FlightRadarAPI
 
 </div>
 
-[Contribute Your Own](https://github.com/JeanExtreme002/FlightRadarAPI/edit/master/docs/projects.md){ .md-button .md-button--primary }
+[Contribute Your Own :writing_hand:](https://github.com/JeanExtreme002/FlightRadarAPI/edit/main/docs/projects.md){ .md-button .md-button--primary }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/JeanExtreme002/FlightRadarAPI
 docs_dir: docs
 site_description: Documentation for the FlightRadarAPI
 site_author: JeanExtreme002
+edit_uri: edit/main/docs/
 
 nav:
   - Home: index.md
@@ -24,6 +25,7 @@ theme:
     - search.highlight
     - search.share
     - content.tooltips
+    - content.tabs.link
     
   icon:
     repo: fontawesome/brands/github
@@ -41,7 +43,6 @@ extra:
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
   - attr_list
   - md_in_html
   - abbr
@@ -50,6 +51,9 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.superfences
 
 plugins:
   - git-committers:


### PR DESCRIPTION
Just some small changes to the docs, including:

- Fix page edit button not working
- Rename NodeJS to Node.js
- Add pip and npm links to install section
- Other small changes

**Also, as I mentioned in my previous PR:**

I would recommend updating the homepage link on the GitHub repo from the current one:
![screenshot](https://github.com/JeanExtreme002/FlightRadarAPI/assets/133548095/052a2cc0-8f00-44a4-b3f6-614401a6fb03)

to the docs homepage (https://jeanextreme002.github.io/FlightRadarAPI/) to make it easier for people to get to the docs. There are links to both PyPI and NPM on the docs homepage.

It would also be worth deleting the wiki as it is not really needed any more.