### PR TITLE
fix: update headers to bypass Cloudflare 403 Forbidden blocks

### DIFF
--- a/nodejs/FlightRadar24/core.js
+++ b/nodejs/FlightRadar24/core.js
@@ -73,6 +73,7 @@ class Core {
         this.headers = {
             "accept-encoding": "gzip, br",
             "accept-language": "en-US,en;q=0.9",
+            "cache-control": "max-age=0",
             "user-agent": "Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1",
         };
 

--- a/nodejs/FlightRadar24/core.js
+++ b/nodejs/FlightRadar24/core.js
@@ -72,14 +72,8 @@ class Core {
 
         this.headers = {
             "accept-encoding": "gzip, br",
-            "accept-language": "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7",
-            "cache-control": "max-age=0",
-            "origin": "https://www.flightradar24.com",
-            "referer": "https://www.flightradar24.com/",
-            "sec-fetch-dest": "empty",
-            "sec-fetch-mode": "cors",
-            "sec-fetch-site": "same-site",
-            "user-agent": "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
+            "accept-language": "en-US,en;q=0.9",
+            "user-agent": "Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1",
         };
 
         this.jsonHeaders = {accept: "application/json", ...this.headers};

--- a/python/FlightRadar24/core.py
+++ b/python/FlightRadar24/core.py
@@ -62,14 +62,8 @@ class Core(ABC):
 
     headers = {
         "accept-encoding": "gzip, br",
-        "accept-language": "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7",
-        "cache-control": "max-age=0",
-        "origin": "https://www.flightradar24.com",
-        "referer": "https://www.flightradar24.com/",
-        "sec-fetch-dest": "empty",
-        "sec-fetch-mode": "cors",
-        "sec-fetch-site": "same-site",
-        "user-agent": "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
+        "accept-language": "en-US,en;q=0.9",
+        "user-agent": "Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1",
     }
 
     json_headers = headers.copy()

--- a/python/FlightRadar24/core.py
+++ b/python/FlightRadar24/core.py
@@ -63,6 +63,7 @@ class Core(ABC):
     headers = {
         "accept-encoding": "gzip, br",
         "accept-language": "en-US,en;q=0.9",
+        "cache-control": "max-age=0",
         "user-agent": "Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1",
     }
 


### PR DESCRIPTION
### Description
This PR addresses the persistent `403 Forbidden` errors encountered when using various functions of the library (such as `search()`, `getFlights()`, or `getFlightDetails()`). These errors are caused by FlightRadar24's Cloudflare protection blocking the default browser-based headers.

### Root Cause
Cloudflare's security measures currently flag and block the outdated Chrome/Windows 7 `User-Agent` string used by default in `core.js` and `core.py`. This results in the client receiving a "Just a moment..." challenge page or a direct 403 response instead of the requested JSON/data.

### Solution
The fix involves updating the global headers in `core.js` and `core.py` to mimic the **official FlightRadar24 mobile application (iOS)**. Mobile app traffic is generally subject to different filtering rules and is currently not blocked by the Cloudflare challenges affecting browser-like requests from scripts.

**Key Changes:**
*   **User-Agent:** Switched to a valid mobile app string: `Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1`.
*   **Header Cleanup:** Removed unnecessary browser-specific headers (`origin`, `referer`, `sec-fetch-*`) that are not used by the mobile API and can serve as bot fingerprints.
*   **Global Fix:** Since these changes are in the `Core` class, they automatically apply to all API requests made by the library.