### PR TITLE
ci: add dependabot for security-only updates and PR labeler workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+# Security-only updates.
+# `open-pull-requests-limit: 0` disables version-update PRs while still
+# allowing Dependabot to open PRs for security advisories.
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+updates:
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "deps"
+      - "security"
+
+  - package-ecosystem: "npm"
+    directory: "/nodejs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "deps"
+      - "security"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "deps"
+      - "security"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,158 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply PR labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = (pr.user && pr.user.login) || "";
+            const isDependabot =
+              author === "dependabot[bot]" ||
+              author === "dependabot-preview[bot]";
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              }
+            );
+            const paths = files.map((f) => f.filename);
+            core.info(`Changed files (${paths.length}):\n  ` + paths.join("\n  "));
+
+            const isCore = (f) =>
+              f === "python/FlightRadarAPI/core.py" ||
+              f === "python/FlightRadarAPI/request.py" ||
+              f === "nodejs/FlightRadarAPI/core.js" ||
+              f === "nodejs/FlightRadarAPI/request.js";
+
+            const isEntities = (f) =>
+              /^(python|nodejs)\/FlightRadarAPI\/entities\//.test(f);
+
+            const isInPackage = (f) =>
+              /^(python|nodejs)\/FlightRadarAPI\//.test(f);
+
+            const isTests = (f) => /^(python|nodejs)\/tests\//.test(f);
+
+            const isCi = (f) => f.startsWith(".github/");
+
+            const isDeps = (f) =>
+              f === "python/pyproject.toml" ||
+              f === "nodejs/package.json" ||
+              f === "nodejs/package-lock.json";
+
+            const isBuild = (f) =>
+              /(^|\/)Makefile$/.test(f) ||
+              f === "nodejs/.eslintrc.json" ||
+              f === "python/.flake8" ||
+              f === ".gitignore" ||
+              f === "nodejs/.npmignore";
+
+            const isDocs = (f) =>
+              f.startsWith("docs/") ||
+              f === "mkdocs.yml" ||
+              /\.md$/i.test(f);
+
+            const isPython = (f) => f.startsWith("python/");
+            const isNode = (f) => f.startsWith("nodejs/");
+
+            const desired = new Set();
+
+            for (const f of paths) {
+              if (isCore(f)) desired.add("api:core");
+              if (isEntities(f)) desired.add("api:entities");
+              if (isInPackage(f) && !isCore(f) && !isEntities(f)) desired.add("api");
+              if (isTests(f)) desired.add("tests");
+              if (isCi(f)) desired.add("ci");
+              if (isDeps(f)) desired.add("deps");
+              if (isBuild(f)) desired.add("build");
+              if (isDocs(f)) desired.add("docs");
+              if (isPython(f)) desired.add("pkg:python");
+              if (isNode(f)) desired.add("pkg:node");
+            }
+
+            // Dependabot PRs (we only enable Dependabot for security advisories).
+            if (isDependabot) {
+              desired.add("deps");
+              desired.add("security");
+            }
+
+            // Title-based detection (conventional commits: `type(scope)!: subject`).
+            const titleMap = {
+              feat: "feature",
+              fix: "bug",
+              perf: "performance",
+              revert: "revert",
+              docs: "docs",
+              ci: "ci",
+              build: "build",
+            };
+            const title = pr.title || "";
+            const titleMatch = title.match(/^(\w+)(?:\(([^)]+)\))?!?:/);
+            const titleType = titleMatch ? titleMatch[1].toLowerCase() : null;
+            const titleScope = titleMatch && titleMatch[2]
+              ? titleMatch[2].toLowerCase()
+              : null;
+            if (titleType && titleMap[titleType]) {
+              desired.add(titleMap[titleType]);
+            }
+            if (titleScope === "deps" || titleScope === "deps-dev") {
+              desired.add("deps");
+            }
+
+            // Sync: only manage our labels — leave anything else (issue labels, etc.) alone.
+            const managed = new Set([
+              "api:core", "api:entities", "api", "tests",
+              "ci", "build", "feature", "docs",
+              "revert", "performance", "bug",
+              "deps", "security", "pkg:python", "pkg:node",
+            ]);
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+            const current = new Set(currentLabels.map((l) => l.name));
+
+            const toAdd = [...desired].filter((l) => !current.has(l));
+            const toRemove = [...current].filter(
+              (l) => managed.has(l) && !desired.has(l)
+            );
+
+            for (const name of toRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                name,
+              });
+            }
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: toAdd,
+              });
+            }
+
+            core.info(
+              `Desired: [${[...desired].join(", ")}] | ` +
+              `Added: [${toAdd.join(", ")}] | ` +
+              `Removed: [${toRemove.join(", ")}]`
+            );


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**
This pull request introduces two new configuration files to improve repository automation and security. It adds a Dependabot configuration to enable security-focused dependency updates for Python, Node.js, and GitHub Actions, and implements a GitHub Actions workflow that automatically applies relevant labels to pull requests based on file changes, PR author, and PR title.

**Dependency and security automation:**

* Added `.github/dependabot.yml` to enable Dependabot for Python (`pip`), Node.js (`npm`), and GitHub Actions, configured to only open pull requests for security advisories and automatically label them as `deps` and `security`.

**Pull request labeling automation:**

* Introduced `.github/workflows/labeler.yml` workflow that applies and manages PR labels based on changed files, PR author (including special handling for Dependabot), and PR title (supporting conventional commit types and scopes). This helps categorize PRs automatically (e.g., `api:core`, `tests`, `ci`, `docs`, `deps`, `security`, `pkg:python`, `pkg:node`).
<!-- 
IMPORTANT! Explain the **motivation** for making this change: what existing
problem the pull request solves or what new features it implements.
-->

**Checklist (complete all items)**:

- [ x ] Added tests as necessary.
- [ x ] There is no breaking change for existing features.

**References:**

<!-- (Nice to have) 
Link tasks, issues, PRs that are related to this pull request, etc. 
-->

No references to be shared. 

**Notes:**

<!-- (Optional) 
Explain some changes that can be useful when reviewing this pull request. 
-->

No notes to be shared. 