### PR TITLE
ci: auto-delete PR head branch on close

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,43 @@
+name: Delete merged branch
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete:
+    name: Delete head branch after merge
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const ref = pr.head.ref;
+
+            const protectedBranches = new Set(["main", "gh-pages"]);
+            if (protectedBranches.has(ref)) {
+              core.info(`Refusing to delete protected branch: ${ref}`);
+              return;
+            }
+
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${ref}`,
+              });
+              core.info(`Deleted branch: ${ref}`);
+            } catch (err) {
+              if (err.status === 422 || err.status === 404) {
+                core.info(`Branch already gone: ${ref}`);
+                return;
+              }
+              throw err;
+            }

--- a/.github/workflows/delete-pr-branch.yml
+++ b/.github/workflows/delete-pr-branch.yml
@@ -1,4 +1,4 @@
-name: Delete merged branch
+name: Delete PR branch
 
 on:
   pull_request:
@@ -9,10 +9,8 @@ permissions:
 
 jobs:
   delete:
-    name: Delete head branch after merge
-    if: >-
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    name: Delete head branch after PR close
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/delete-pr-branch.yml` to delete a PR's head branch automatically whenever the PR is closed (merged **or** abandoned).
- Skips protected branches (`main`, `gh-pages`) and PRs from forks (where we can't delete refs anyway).
- Treats 404/422 from the GitHub API as already-deleted (no-op), so re-runs and manual deletions don't fail the job.

Motivation: repo currently has `deleteBranchOnMerge: false`, so merged branches stick around (e.g. `jeanextreme002/*` and `ci/*` from recent PRs are still on the remote). This also cleans up branches from PRs that get closed without merging, which the repo-level setting wouldn't cover.

Alternative — and complementary — fix: flip on **Settings → General → Automatically delete head branches** in the repo UI. The workflow still adds value because (a) it also handles closed-without-merge and (b) it keeps cleanup behavior in version control.

## Test plan
- [ ] Merge this PR and confirm the `ci/delete-branch-on-merge` head branch is deleted automatically by the new workflow run.
- [ ] Open and merge a follow-up no-op PR from a non-protected branch; confirm the head branch is deleted.
- [ ] Open and **close without merging** a throwaway PR; confirm the head branch is also deleted.
- [ ] Verify a hypothetical PR targeting `main` from a fork is a no-op (guarded by the `head.repo.full_name == github.repository` check).