### PR TITLE
ci: lint PR titles with conventional commit rules

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,46 @@
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional commit title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Conventional commit types accepted in titles. Mirrors the set the
+          # PR labeler recognizes in .github/workflows/labeler.yml.
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            revert
+            docs
+            ci
+            build
+            chore
+            test
+            style
+          # Subject must start lowercase and not end with a period.
+          subjectPattern: ^(?![A-Z])(?!.*\.$).+$
+          subjectPatternError: |
+            The subject "{subject}" found in "{title}" must start with a
+            lowercase letter and must not end with a period.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/lint-pr-title.yml` running `amannn/action-semantic-pull-request@v5` on PR `opened`/`edited`/`synchronize`/`reopened`.
- Accepted types match the set the existing PR labeler already recognizes (`feat`, `fix`, `perf`, `refactor`, `revert`, `docs`, `ci`, `build`) plus `chore`, `test`, `style`.
- Subjects must start lowercase and not end with a period.
- Scopes are **not** constrained — titles with or without a scope both pass.
- Uses `pull_request_target` with `permissions: pull-requests: read` so it works for PRs from forks without exposing write tokens to PR code.

## Test plan
- [ ] After merge, open a PR with a valid title (e.g. `fix: foo bar`) and confirm the check passes.
- [ ] Open a PR with an invalid type (e.g. `wip: foo`) or capitalized subject (`fix: Foo`) and confirm the check fails.
- [ ] Edit a failing PR's title to a valid one and confirm the check re-runs and turns green.