### PR TITLE
ci: publish npm and PyPI packages automatically on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,26 +1,7 @@
 name: Publish Packages
 
-# Publishes both distributions whenever a GitHub Release is published:
-#   - python/  -> PyPI  (FlightRadarAPI)
-#   - nodejs/  -> npm   (flightradarapi)
-#
-# Both registries are reached via OIDC "trusted publishing", so no long-lived
-# API token is stored in this repository. Setup required once per registry:
-#
-#   PyPI  -> pypi.org > project > Publishing > add a GitHub trusted publisher
-#            (owner: JeanExtreme002, repo: FlightRadarAPI,
-#             workflow: publish.yml, environment: pypi)
-#
-#   npm   -> npmjs.com > package > Settings > Trusted publisher
-#            (GitHub Actions, repo JeanExtreme002/FlightRadarAPI,
-#             workflow publish.yml, environment: npm)
-#            Requires npm >= 11.5.1, which the job installs explicitly.
-#
-# If npm trusted publishing is ever unavailable, swap the publish step for a
-# classic token: set the NPM_TOKEN secret and add
-#   env:
-#     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-# to the `npm publish` step (the setup-node registry-url is already in place).
+# Both registries use OIDC trusted publishing, which must be configured once
+# on pypi.org and npmjs.com for this repo, workflow file and environment.
 
 on:
   release:
@@ -41,9 +22,6 @@ permissions:
   contents: read
 
 jobs:
-  # Guard rail: the release tag must match the version declared in both
-  # manifests. Without this, a mistyped tag would silently republish the
-  # version that is already on the registry (or publish the wrong one).
   verify-versions:
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +46,6 @@ jobs:
       - name: Check versions match the release tag
         if: github.event_name == 'release'
         run: |
-          # Accepts both "v1.5.2" and "1.5.2" tags.
           tag="${{ github.event.release.tag_name }}"
           tag="${tag#v}"
           if [ "$tag" != "${{ steps.versions.outputs.python }}" ]; then
@@ -144,8 +121,8 @@ jobs:
         run: npm run test:types
 
       - name: Offline tests
-        # Live FR24 integration tests are intentionally excluded: a flaky
-        # upstream response must never block a release that already passed CI.
+        # Live FR24 integration tests are left out on purpose: a flaky upstream
+        # response must not block a release that already passed CI.
         run: npm run test:offline
 
       - name: Validate package contents

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,156 @@
+name: Publish Packages
+
+# Publishes both distributions whenever a GitHub Release is published:
+#   - python/  -> PyPI  (FlightRadarAPI)
+#   - nodejs/  -> npm   (flightradarapi)
+#
+# Both registries are reached via OIDC "trusted publishing", so no long-lived
+# API token is stored in this repository. Setup required once per registry:
+#
+#   PyPI  -> pypi.org > project > Publishing > add a GitHub trusted publisher
+#            (owner: JeanExtreme002, repo: FlightRadarAPI,
+#             workflow: publish.yml, environment: pypi)
+#
+#   npm   -> npmjs.com > package > Settings > Trusted publisher
+#            (GitHub Actions, repo JeanExtreme002/FlightRadarAPI,
+#             workflow publish.yml, environment: npm)
+#            Requires npm >= 11.5.1, which the job installs explicitly.
+#
+# If npm trusted publishing is ever unavailable, swap the publish step for a
+# classic token: set the NPM_TOKEN secret and add
+#   env:
+#     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+# to the `npm publish` step (the setup-node registry-url is already in place).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which package(s) to publish'
+        type: choice
+        options: [both, pypi, npm]
+        default: both
+      dry_run:
+        description: 'Build and validate only, without uploading'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Guard rail: the release tag must match the version declared in both
+  # manifests. Without this, a mistyped tag would silently republish the
+  # version that is already on the registry (or publish the wrong one).
+  verify-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read declared versions
+        id: versions
+        run: |
+          py_version=$(grep -oP '__version__\s*=\s*"\K[^"]+' python/FlightRadarAPI/__init__.py)
+          npm_version=$(node -p "require('./nodejs/package.json').version")
+          echo "python=$py_version" >> "$GITHUB_OUTPUT"
+          echo "npm=$npm_version" >> "$GITHUB_OUTPUT"
+          echo "Python: $py_version | npm: $npm_version"
+
+      - name: Check versions are in sync
+        run: |
+          if [ "${{ steps.versions.outputs.python }}" != "${{ steps.versions.outputs.npm }}" ]; then
+            echo "::error::Version mismatch: python=${{ steps.versions.outputs.python }} npm=${{ steps.versions.outputs.npm }}"
+            exit 1
+          fi
+
+      - name: Check versions match the release tag
+        if: github.event_name == 'release'
+        run: |
+          # Accepts both "v1.5.2" and "1.5.2" tags.
+          tag="${{ github.event.release.tag_name }}"
+          tag="${tag#v}"
+          if [ "$tag" != "${{ steps.versions.outputs.python }}" ]; then
+            echo "::error::Release tag $tag does not match package version ${{ steps.versions.outputs.python }}"
+            exit 1
+          fi
+
+  publish-pypi:
+    needs: verify-versions
+    if: github.event_name == 'release' || inputs.target == 'both' || inputs.target == 'pypi'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build package
+        run: python -m build ./python
+
+      - name: Validate distributions
+        run: python -m twine check python/dist/*
+
+      - name: Verify the built wheel imports
+        run: |
+          pip install python/dist/*.whl
+          python -c "from FlightRadarAPI import FlightRadar24API; FlightRadar24API(); print('Install OK')"
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release' || inputs.dry_run == false
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/
+
+  publish-npm:
+    needs: verify-versions
+    if: github.event_name == 'release' || inputs.target == 'both' || inputs.target == 'npm'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      id-token: write  # Required for trusted publishing (OIDC) + provenance
+    defaults:
+      run:
+        working-directory: ./nodejs
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm
+        # npm trusted publishing (OIDC) requires npm >= 11.5.1.
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run test:types
+
+      - name: Offline tests
+        # Live FR24 integration tests are intentionally excluded: a flaky
+        # upstream response must never block a release that already passed CI.
+        run: npm run test:offline
+
+      - name: Validate package contents
+        run: npm publish --dry-run
+
+      - name: Publish to npm
+        if: github.event_name == 'release' || inputs.dry_run == false
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## What changes

Adds `.github/workflows/publish.yml`, triggered by `release: [published]`, which ships both distributions from a single release:

- `python/` → PyPI (`FlightRadarAPI`)
- `nodejs/` → npm (`flightradarapi`)

It follows the same pattern as the `pymemoryeditor` publish workflow: **OIDC trusted publishing**, so no long-lived registry token is stored in this repository.

## Jobs

1. **`verify-versions`** — reads the version from `python/FlightRadarAPI/__init__.py` and `nodejs/package.json`, requires them to match each other and to match the release tag (accepts either `v1.5.2` or `1.5.2`). Without this gate, a mistyped tag would silently republish the version already on the registry.
2. **`publish-pypi`** — `python -m build ./python`, `twine check`, installs the built wheel and confirms `from FlightRadarAPI import FlightRadar24API` works, and only then publishes via `pypa/gh-action-pypi-publish`.
3. **`publish-npm`** — `npm ci`, lint, type check, `test:offline`, `npm publish --dry-run` to validate the tarball contents, then publishes with `npm publish --provenance --access public`.

Live FR24 integration tests are deliberately left out of the publish gate: a flaky upstream response must not block a release that already passed CI.

`workflow_dispatch` accepts `target` (`both`/`pypi`/`npm`) and `dry_run` (defaults to `true`), so the whole pipeline can be exercised without uploading anything.

## Setup required before the first release

Publishing fails without these credentials in place:

- **PyPI** — pypi.org → `FlightRadarAPI` project → Publishing → add a GitHub trusted publisher: owner `JeanExtreme002`, repo `FlightRadarAPI`, workflow `publish.yml`, environment `pypi`.
- **npm** — npmjs.com → `flightradarapi` package → Settings → Trusted publisher: GitHub Actions, repo `JeanExtreme002/FlightRadarAPI`, workflow `publish.yml`, environment `npm`. The job installs `npm@latest` because trusted publishing requires npm >= 11.5.1.

If npm trusted publishing is ever unworkable, the fallback is a classic token: set an `NPM_TOKEN` secret and add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the publish step — the `setup-node` `registry-url` is already in place.

## Verification

The YAML was validated and the version extraction tested locally (both manifests are currently at `1.5.2`). The jobs themselves have not been run — a first `workflow_dispatch` with `dry_run: true` covers that.