### PR TITLE
chore: bump every port to 1.6.1

### DIFF
--- a/go/flightradarapi/doc.go
+++ b/go/flightradarapi/doc.go
@@ -33,7 +33,7 @@
 package flightradarapi
 
 // Version of this package.
-const Version = "1.6.0"
+const Version = "1.6.1"
 
 // Author of this package.
 const Author = "Jean Loui Bernard Silva de Jesus"

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flightradarapi",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flightradarapi",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "node-html-parser": "^6.1.13",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flightradarapi",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "SDK for FlightRadar24",
   "main": "./FlightRadarAPI/index.js",
   "types": "./FlightRadarAPI/index.d.ts",

--- a/python/FlightRadarAPI/__init__.py
+++ b/python/FlightRadarAPI/__init__.py
@@ -12,7 +12,7 @@ https://www.flightradar24.com/terms-and-conditions
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 from .api import FlightRadar24API
 from .core import Countries


### PR DESCRIPTION
Moves the three declared versions to 1.6.1, which is what a release of that
number needs: `verify-versions` refuses to publish anything unless Python,
Node.js and Go all declare the same one.

| file | field |
| --- | --- |
| `python/FlightRadarAPI/__init__.py` | `__version__` |
| `nodejs/package.json` | `version` |
| `nodejs/package-lock.json` | `version` (both entries) |
| `go/flightradarapi/doc.go` | `Version` |

The Node side was bumped with `npm version --no-git-tag-version`, so the lock
file moves with the manifest — `npm ci`, which the workflow runs, fails on a
lock that disagrees with it. The `fastq: ^1.6.0` dependency further down that
file is untouched.

## Checked

The same three extractions the release gate performs:

```
python=1.6.1 | npm=1.6.1 | go=1.6.1   → verify-versions would pass
npm ci                                 → accepted the lock file
go test ./flightradarapi               → ok
import FlightRadarAPI                  → 1.6.1, client instantiates
```

## After merging

Publishing the `v1.6.1` release runs the whole chain: PyPI, npm, and then the
`go/v1.6.1` tag, which the Go toolchain needs because the module lives in a
subdirectory. Nothing to tag by hand this time.